### PR TITLE
avoid having multiple locations with the same key

### DIFF
--- a/src/components/stats/locations.tsx
+++ b/src/components/stats/locations.tsx
@@ -33,6 +33,7 @@ export function LocationStats({ link }: LocationStatsProps) {
   const pages = useMemo(
     () =>
       data?.map(location => ({
+        key: `${location.country ?? 'X'}-${location.name}`,
         name: countryLists[location.name as CountryCode] ?? location.name,
         value: location.value,
         icon: function Icon() {


### PR DESCRIPTION
Some cities could be "unknown", which could result in multiple cities having "unknown" as their key.